### PR TITLE
Universal - onValidateSession argument + "CARD_FUNDING_TYPE_UPDATE" event

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -423,7 +423,8 @@ export enum EVENT_TYPES {
   PAYMENT_PENDING_APPROVAL = 'payment_pending_approval',
   SET_DISABLE_UI = 'set_disable_ui',
   HEADLESS_READY = 'headless_ready',
-  FORM_VALIDATION_UPDATED = 'form_validation_update'
+  FORM_VALIDATION_UPDATED = 'form_validation_update',
+  CARD_FUNDING_TYPE_UPDATE = 'card_funding_type_update'
 }
 
 export type ListenerFn = (

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -277,6 +277,10 @@ export interface UniversalOpts {
   toggles?: UniversalToggles
   selectedPaymentMethod?: string
   apmsOnClickValidation?: () => Promise<boolean>
+  onValidateSession?: (data: {
+    paymentMethodType: string
+    fundingType?: CardFunding
+  }) => Promise<boolean>
   localizations?: {
     [language: string]: LanguageLocalizationOverride
   }
@@ -653,6 +657,8 @@ export type PaymentMethod = {
   supportedCardBrands?: CardBrand[]
 }
 
+export type CardFunding = 'prepaid' | 'debit' | 'credit' | 'charge'
+
 export type ExistingCard = {
   bin: string
   brand: CardBrand
@@ -663,7 +669,7 @@ export type ExistingCard = {
   expYear: string
   last4: string
   fingerprint: string
-  funding: 'prepaid' | 'debit' | 'credit' | 'charge'
+  funding: CardFunding
   network: CardBrand
   payout: string
   cvvExists?: boolean


### PR DESCRIPTION
**Added `onValidateSession` as universal arguemnt.**
This function will be called on `applepay` / `googlepay` flow - after the user pick the card, before the money movement.
The function will be called with the card funding type value (credit / debit / prepaid).

**Added `EVENT_TYPES.CARD_FUNDING_TYPE_UPDATE`**
This event will be triggered with the selected card funding type when:
1. The user pick a saved card / click-to-pay card
2. The user type in a valid card number

Note: The event will be triggered with `({ fundingType: null })` if one of the following occurred:
* The user selected APM
* The user selected non-card saved source
* The typed-in card number changed from valid to invalid