### PR TITLE
HeadlessPaymentOptions.forceRedirect

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -571,6 +571,7 @@ export type AddressType = {
 export type HeadlessPaymentOptions = {
   saveSourceForFutureUse?: boolean
   onValidateSession?: OnValidateSessionFn
+  forceRedirect?: boolean
 }
 
 export type HeadlessFn = (


### PR DESCRIPTION
`checkout.headless('<apm>', null,null, { forceRedirect: true })` makes headless APM redirect flows follow the provider url as a navigation instead of open it in a modal/new tab mode.